### PR TITLE
chore(tests) CI test for prs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI Suite
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  run_linters:
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    name: Run Linters
+    runs-on: ubuntu-latest
+    concurrency:
+      group: run_linters-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 20.x]
+    steps: 
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install yarn
+        run: npm install yarn@latest -g
+      - name: Install dependencies
+        run: yarn install --immutable
+      - name: Run lint, test, build
+        run: |
+          yarn lint
+          yarn test
+          yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     name: Run Linters
     runs-on: ubuntu-latest
-    concurrency:
-      group: run_linters-${{ github.head_ref || github.run_id }}
-      cancel-in-progress: true
     strategy:
       matrix:
         node-version: [14.x, 16.x, 20.x]


### PR DESCRIPTION
Have the CI tests from "Deploy" run on the main branch and any pr request to the main branch
Also pushes the test matrix to use the current nodejs LTS

((Optionally, use latest yarn (v3) so that the CI can cache installing dependencies on `.yarn/cache`))